### PR TITLE
손해사정사 관련 클래스 모두 구현, Menu에 payCompensation구현

### DIFF
--- a/src/main/Compensation.java
+++ b/src/main/Compensation.java
@@ -1,25 +1,28 @@
 package main;
-import java.util.Date;
 import java.util.Objects;
 
 public class Compensation {
+
+	/**
+	 * Class 다이어그램과 다른점 몇가지
+	 * 1. resultOFPaid와 PaidState를 합침
+	 */
+
 
 	// Example Fields
 	private final String compensationID;
 	private final String evaluationID; // Link to an Evaluation
 	private final String customerID;   // Link to a Customer
-	private ProcessState paidState;
-	private boolean resultOfPaid;
-	private int claimsPaid;
+	private ProcessState resultOfPaid;
+	private int amountOfPaid;
 	// Builder Pattern
 
 	private Compensation(Builder builder) {
 		this.compensationID = builder.compensationID;
 		this.evaluationID = builder.evaluationID;
 		this.customerID = builder.customerID;
-		this.claimsPaid = builder.claimsPaid;
-		this.paidState = ProcessState.Awaiting;
-		this.resultOfPaid = false;
+		this.amountOfPaid = builder.claimsPaid;
+		this.resultOfPaid = ProcessState.Awaiting;
 	}
 
 	// Getters
@@ -36,35 +39,28 @@ public class Compensation {
 	}
 
 	public ProcessState getState() {
-		return paidState;
-	}
-
-	public int getClaimsPaid() {
-		return claimsPaid;
-	}
-	public boolean getResultOfPaid() {
 		return resultOfPaid;
 	}
-	public ProcessState getPaidState(){
-		return paidState;
+
+	public int getAmountOfPaid() {
+		return amountOfPaid;
+	}
+	public ProcessState getResultOfPaid(){
+		return resultOfPaid;
 	}
 
 	// setter?
 	public void receiptCompensation(boolean isReceipt){
 		if(isReceipt) {
-			this.paidState = ProcessState.Completed;
+			this.resultOfPaid = ProcessState.Completed;
 		}
 		else {
-			this.paidState = ProcessState.Rejected;
+			this.resultOfPaid = ProcessState.Rejected;
 		}
 	}
 
-	public void setResultOfPaid(boolean resultOfPaid) {
-		this.resultOfPaid = resultOfPaid;
-	}
-
-	public void setClaimsPaid(int paid){
-		this.claimsPaid = paid;
+	public void setAmountOfPaid(int paid){
+		this.amountOfPaid = paid;
   }
 
 	public static class Builder {
@@ -107,8 +103,8 @@ public class Compensation {
 				"compensationID='" + compensationID + '\'' +
 				", evaluationID='" + evaluationID + '\'' +
 				", customerID='" + customerID + '\'' +
-				", paidState=" + paidState +
-				", claimsPaid=" + claimsPaid +
+				", paidState=" + resultOfPaid +
+				", claimsPaid=" + amountOfPaid +
 				'}';
 	}
 
@@ -117,7 +113,8 @@ public class Compensation {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		Compensation that = (Compensation) o;
-		return claimsPaid == that.claimsPaid && Objects.equals(compensationID, that.compensationID) && Objects.equals(evaluationID, that.evaluationID) && Objects.equals(customerID, that.customerID) && paidState == that.paidState;
+		return amountOfPaid == that.amountOfPaid && Objects.equals(compensationID, that.compensationID) && Objects.equals(evaluationID, that.evaluationID) && Objects.equals(customerID, that.customerID) && resultOfPaid
+				== that.resultOfPaid;
 	}
 
 }

--- a/src/main/Compensation.java
+++ b/src/main/Compensation.java
@@ -1,0 +1,110 @@
+import java.util.Date;
+import java.util.Objects;
+
+public class Compensation {
+
+	// Example Fields
+	private final String compensationID;
+	private final String evaluationID; // Link to an Evaluation
+	private final String customerID;   // Link to a Customer
+	private ProcessState paidState;
+	private int claimsPaid;
+	// Builder Pattern
+
+	private Compensation(Builder builder) {
+		this.compensationID = builder.compensationID;
+		this.evaluationID = builder.evaluationID;
+		this.customerID = builder.customerID;
+		this.paidState = builder.paidState;
+		this.claimsPaid = builder.claimsPaid;
+	}
+
+	// Getters
+	public String getCompensationID() {
+		return compensationID;
+	}
+
+	public String getEvaluationID() {
+		return evaluationID;
+	}
+
+	public String getCustomerID() {
+		return customerID;
+	}
+
+	public ProcessState getState() {
+		return paidState;
+	}
+
+	public int getClaimsPaid() {
+		return claimsPaid;
+	}
+
+	// setter?
+	public void receiptCompensation(boolean isReceipt){
+		if(isReceipt) {
+			this.paidState = ProcessState.Completed;
+		}
+		else {
+			this.paidState = ProcessState.Rejected;
+		}
+	}
+
+	public void setClaimsPaid(int paid){
+		this.claimsPaid = paid;
+  }
+
+	public static class Builder {
+		private final String evaluationID;
+		private final String customerID;
+		private final String compensationID;
+		private ProcessState paidState;
+		private int claimsPaid;
+
+
+		public Builder(String compensationID,String evaluationID, String customerID) {
+			this.evaluationID = evaluationID;
+			this.customerID = customerID;
+			this.compensationID = compensationID;
+			this.paidState = ProcessState.Awaiting;
+			this.claimsPaid = 0;
+
+		}
+
+		public Builder paidState(ProcessState paidState) {
+			this.paidState = paidState;
+			return this;
+		}
+
+		public Builder claimsPaid(int claimsPaid) {
+			this.claimsPaid = claimsPaid;
+			return this;
+		}
+
+
+		public Compensation build() {
+			return new Compensation(this);
+		}
+	}
+
+
+	@Override
+	public String toString() {
+		return "Compensation{" +
+				"compensationID='" + compensationID + '\'' +
+				", evaluationID='" + evaluationID + '\'' +
+				", customerID='" + customerID + '\'' +
+				", paidState=" + paidState +
+				", claimsPaid=" + claimsPaid +
+				'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Compensation that = (Compensation) o;
+		return claimsPaid == that.claimsPaid && Objects.equals(compensationID, that.compensationID) && Objects.equals(evaluationID, that.evaluationID) && Objects.equals(customerID, that.customerID) && paidState == that.paidState;
+	}
+
+}

--- a/src/main/Compensation.java
+++ b/src/main/Compensation.java
@@ -1,3 +1,4 @@
+package main;
 import java.util.Date;
 import java.util.Objects;
 
@@ -8,6 +9,7 @@ public class Compensation {
 	private final String evaluationID; // Link to an Evaluation
 	private final String customerID;   // Link to a Customer
 	private ProcessState paidState;
+	private boolean resultOfPaid;
 	private int claimsPaid;
 	// Builder Pattern
 
@@ -15,8 +17,9 @@ public class Compensation {
 		this.compensationID = builder.compensationID;
 		this.evaluationID = builder.evaluationID;
 		this.customerID = builder.customerID;
-		this.paidState = builder.paidState;
 		this.claimsPaid = builder.claimsPaid;
+		this.paidState = ProcessState.Awaiting;
+		this.resultOfPaid = false;
 	}
 
 	// Getters
@@ -38,6 +41,12 @@ public class Compensation {
 
 	public int getClaimsPaid() {
 		return claimsPaid;
+	}
+	public boolean getResultOfPaid() {
+		return resultOfPaid;
+	}
+	public ProcessState getPaidState(){
+		return paidState;
 	}
 
 	// setter?

--- a/src/main/Compensation.java
+++ b/src/main/Compensation.java
@@ -59,6 +59,10 @@ public class Compensation {
 		}
 	}
 
+	public void setResultOfPaid(boolean resultOfPaid) {
+		this.resultOfPaid = resultOfPaid;
+	}
+
 	public void setClaimsPaid(int paid){
 		this.claimsPaid = paid;
   }

--- a/src/main/Evaluation.java
+++ b/src/main/Evaluation.java
@@ -1,4 +1,4 @@
-import java.util.Date;
+package main;
 import java.util.Objects;
 
 public class Evaluation {
@@ -7,16 +7,16 @@ public class Evaluation {
 	private final String evaluationID;
 	private final String eventID;
 	private final String customerID;
-	private ProcessState evaluationState;
-	private Compensation m_Compensation;
+	private ProcessState resultOfEvaluation;
+	private Compensation compensation;
 
 	// Private constructor to be used by the Builder
 	private Evaluation(Builder builder) {
 		this.evaluationID = builder.evaluationID;
 		this.eventID = builder.eventID;
 		this.customerID = builder.customerID;
-		this.m_Compensation = builder.m_Compensation;
-		this.evaluationState = ProcessState.Awaiting;
+		this.compensation = builder.m_Compensation;
+		this.resultOfEvaluation = ProcessState.Awaiting;
 	}
 
 	// Getters
@@ -28,24 +28,28 @@ public class Evaluation {
 		return eventID;
 	}
 
-	public Compensation getM_Compensation() {return m_Compensation;}
+	public Compensation getCompensation() {return compensation;}
 
-	public ProcessState getState() {
-		return evaluationState;
+	public ProcessState getResultOfEvaluation() {
+		return resultOfEvaluation;
 	}
 
 	// setter
-	public void setM_Compensation(Compensation m_Compensation) {
-		this.m_Compensation = m_Compensation;
+	public void setCompensation(Compensation compensation) {
+		this.compensation = compensation;
 	}
 //m_Compensation
 
+
+	/**
+	 * @param isReceipt 심사 통과하려면 False, 거부하려면 False
+	 */
 	public void receiptEvaluation(boolean isReceipt){
 		if(isReceipt) {
-			this.evaluationState = ProcessState.Completed;
+			this.resultOfEvaluation = ProcessState.Completed;
 		}
 		else {
-			this.evaluationState = ProcessState.Rejected;
+			this.resultOfEvaluation = ProcessState.Rejected;
 		}
 	}
 
@@ -93,8 +97,8 @@ public class Evaluation {
 		return Objects.equals(evaluationID, that.evaluationID) &&
 						Objects.equals(eventID, that.eventID) &&
 						Objects.equals(customerID, that.customerID) &&
-						Objects.equals(evaluationState, that.evaluationState) &&
-						Objects.equals(m_Compensation, that.m_Compensation);
+						Objects.equals(resultOfEvaluation, that.resultOfEvaluation) &&
+						Objects.equals(compensation, that.compensation);
 	}
 
 }

--- a/src/main/Evaluation.java
+++ b/src/main/Evaluation.java
@@ -28,6 +28,8 @@ public class Evaluation {
 		return eventID;
 	}
 
+	public String getCustomerID() {return customerID;}
+
 	public Compensation getCompensation() {return compensation;}
 
 	public ProcessState getResultOfEvaluation() {

--- a/src/main/Evaluation.java
+++ b/src/main/Evaluation.java
@@ -1,0 +1,100 @@
+import java.util.Date;
+import java.util.Objects;
+
+public class Evaluation {
+
+
+	private final String evaluationID;
+	private final String eventID;
+	private final String customerID;
+	private ProcessState evaluationState;
+	private Compensation m_Compensation;
+
+	// Private constructor to be used by the Builder
+	private Evaluation(Builder builder) {
+		this.evaluationID = builder.evaluationID;
+		this.eventID = builder.eventID;
+		this.customerID = builder.customerID;
+		this.m_Compensation = builder.m_Compensation;
+		this.evaluationState = ProcessState.Awaiting;
+	}
+
+	// Getters
+	public String getEvaluationID() {
+		return evaluationID;
+	}
+
+	public String getEventID() {
+		return eventID;
+	}
+
+	public Compensation getM_Compensation() {return m_Compensation;}
+
+	public ProcessState getState() {
+		return evaluationState;
+	}
+
+	// setter
+	public void setM_Compensation(Compensation m_Compensation) {
+		this.m_Compensation = m_Compensation;
+	}
+//m_Compensation
+
+	public void receiptEvaluation(boolean isReceipt){
+		if(isReceipt) {
+			this.evaluationState = ProcessState.Completed;
+		}
+		else {
+			this.evaluationState = ProcessState.Rejected;
+		}
+	}
+
+	// toString method
+	@Override
+	public String toString() {
+		return "Evaluation{" +
+				"evaluationID='" + evaluationID + '\'' +
+				", eventID='" + eventID + '\'' +
+				", customerID='"+customerID+'\''+
+				'}';
+	}
+
+	// Builder class
+	public static class Builder {
+		// Required fields
+		private final String eventID;
+		private final String customerID;
+		private final String evaluationID;
+		// Optional fields
+		private Compensation m_Compensation;
+
+
+		public Builder(String evaluationID,String eventID, String customerID) {
+			this.eventID = eventID;
+			this.customerID = customerID;
+			this.evaluationID = evaluationID;
+		}
+
+		public Builder compensation(Compensation compensation) {
+			this.m_Compensation = compensation;
+			return this;
+		}
+
+		public Evaluation build() {
+					return new Evaluation(this);
+		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Evaluation that = (Evaluation) o;
+		return Objects.equals(evaluationID, that.evaluationID) &&
+						Objects.equals(eventID, that.eventID) &&
+						Objects.equals(customerID, that.customerID) &&
+						Objects.equals(evaluationState, that.evaluationState) &&
+						Objects.equals(m_Compensation, that.m_Compensation);
+	}
+
+}

--- a/src/main/Event.java
+++ b/src/main/Event.java
@@ -1,3 +1,4 @@
+package main;
 import java.util.Date;
 import java.util.Objects;
 

--- a/src/main/Event.java
+++ b/src/main/Event.java
@@ -1,0 +1,166 @@
+import java.util.Date;
+import java.util.Objects;
+
+
+/**
+ * @author �ڼֹ�
+ * @version 1.0
+ * @created 11-5-2025 ���� 11:25:09
+ */
+public class Event {
+
+	private int claimValue;
+	public String customerID;
+	private String documents;
+	private Date eventDate;
+	private String eventDescription;
+	public String eventID;
+	private String eventLocation;
+	private Date receiptDate;
+	private ProcessState processState;
+	private Evaluation m_Evaluation;
+
+	private Event(Builder builder) {
+		this.customerID = builder.customerID;
+		this.claimValue = builder.claimValue;
+		this.documents = builder.documents;
+		this.eventDate = builder.eventDate;
+		this.eventDescription = builder.eventDescription;
+		this.eventID = builder.customerID;
+		this.eventLocation = builder.eventLocation;
+		this.receiptDate = builder.receiptDate;
+		this.m_Evaluation = builder.m_Evaluation;
+		this.processState = ProcessState.Awaiting;
+	}
+
+	public int getClaimValue() {
+		return claimValue;
+	}
+
+	public String getCustomerID() {
+		return customerID;
+	}
+
+	public String getDocuments() {
+		return documents;
+	}
+
+	public Date getEventDate() {
+		return eventDate;
+	}
+
+	public String getEventDescription() {
+		return eventDescription;
+	}
+
+	public String getEventID() {
+		return eventID;
+	}
+
+	public String getEventLocation() {
+		return eventLocation;
+	}
+
+	public Date getReceiptDate() {
+		return receiptDate;
+	}
+
+	public Evaluation getM_Evaluation() {
+		return m_Evaluation;
+	}
+	public ProcessState getState() {return processState;}
+
+
+	public void setM_Evaluation(Evaluation m_Evaluation) {
+		this.m_Evaluation = m_Evaluation;
+	}
+//m_Evaluation setter
+
+	public void receiptEvent(boolean isReceipt){
+		if(isReceipt) {
+			this.processState = ProcessState.Completed;
+		}
+		else {
+			this.processState = ProcessState.Rejected;
+		}
+	}
+
+
+	public static class Builder {
+		private final String customerID;
+		private final String eventID;
+		private int claimValue;
+		private String documents;
+		private Date eventDate;
+		private String eventDescription;
+		private String eventLocation;
+		private Date receiptDate;
+		private Evaluation m_Evaluation;
+
+		public Builder(String eventID,String customerID){
+			this.eventID = eventID;
+			this.customerID = customerID;
+		}
+		public Builder claimValue(int claimValue) {
+			this.claimValue = claimValue;
+			return this;
+		}
+
+		public Builder documents(String documents) {
+			this.documents = documents;
+			return this;
+		}
+
+		public Builder eventDate(Date eventDate) {
+			this.eventDate = eventDate;
+			return this;
+		}
+
+		public Builder eventDescription(String eventDescription) {
+			this.eventDescription = eventDescription;
+			return this;
+		}
+
+		public Builder eventLocation(String eventLocation) {
+			this.eventLocation = eventLocation;
+			return this;
+		}
+
+		public Builder receiptDate(Date receiptDate) {
+			this.receiptDate = receiptDate;
+			return this;
+		}
+		public Builder m_Evaluation(Evaluation m_Evaluation) {
+			this.m_Evaluation = m_Evaluation;
+			return this;
+		}
+
+		public Event build() {
+			return new Event(this);
+		}
+	}
+	@Override
+	public String toString() {
+		return "Event{" +
+				"claimValue=" + claimValue +
+				", customerID=" + customerID +
+				", documents='" + documents + '\'' +
+				", eventDate=" + eventDate +
+				", eventDescription=" + eventDescription +
+				", eventID=" + eventID +
+				", eventLocation='" + eventLocation + '\'' +
+				", receiptDate=" + receiptDate +
+				", m_Evaluation=" + m_Evaluation +
+				'}';
+	}
+	public boolean equals(Object o) {
+		if (this == o) {
+      return true;
+    }
+		if (null == o || getClass() != o.getClass()) return false;
+		Event event;
+    event = (Event) o;
+    return claimValue == event.claimValue && Objects.equals(customerID, event.customerID) && Objects.equals(documents, event.documents) && Objects.equals(eventDate, event.eventDate) && Objects.equals(eventDescription, event.eventDescription) && Objects.equals(eventID, event.eventID) && Objects.equals(eventLocation, event.eventLocation) && Objects.equals(receiptDate, event.receiptDate) && Objects.equals(m_Evaluation, event.m_Evaluation);
+	}
+
+}

--- a/src/main/Event.java
+++ b/src/main/Event.java
@@ -18,8 +18,7 @@ public class Event {
 	public String eventID;
 	private String eventLocation;
 	private Date receiptDate;
-	private ProcessState processState;
-	private Evaluation m_Evaluation;
+	private Evaluation evaluation;
 
 	private Event(Builder builder) {
 		this.customerID = builder.customerID;
@@ -30,8 +29,7 @@ public class Event {
 		this.eventID = builder.customerID;
 		this.eventLocation = builder.eventLocation;
 		this.receiptDate = builder.receiptDate;
-		this.m_Evaluation = builder.m_Evaluation;
-		this.processState = ProcessState.Awaiting;
+		this.evaluation = builder.m_Evaluation;
 	}
 
 	public int getClaimValue() {
@@ -66,25 +64,16 @@ public class Event {
 		return receiptDate;
 	}
 
-	public Evaluation getM_Evaluation() {
-		return m_Evaluation;
+	public Evaluation getEvaluation() {
+		return evaluation;
 	}
-	public ProcessState getState() {return processState;}
 
 
-	public void setM_Evaluation(Evaluation m_Evaluation) {
-		this.m_Evaluation = m_Evaluation;
+	public void setEvaluation(Evaluation evaluation) {
+		this.evaluation = evaluation;
 	}
 //m_Evaluation setter
 
-	public void receiptEvent(boolean isReceipt){
-		if(isReceipt) {
-			this.processState = ProcessState.Completed;
-		}
-		else {
-			this.processState = ProcessState.Rejected;
-		}
-	}
 
 
 	public static class Builder {
@@ -151,7 +140,7 @@ public class Event {
 				", eventID=" + eventID +
 				", eventLocation='" + eventLocation + '\'' +
 				", receiptDate=" + receiptDate +
-				", m_Evaluation=" + m_Evaluation +
+				", m_Evaluation=" + evaluation +
 				'}';
 	}
 	public boolean equals(Object o) {
@@ -161,7 +150,8 @@ public class Event {
 		if (null == o || getClass() != o.getClass()) return false;
 		Event event;
     event = (Event) o;
-    return claimValue == event.claimValue && Objects.equals(customerID, event.customerID) && Objects.equals(documents, event.documents) && Objects.equals(eventDate, event.eventDate) && Objects.equals(eventDescription, event.eventDescription) && Objects.equals(eventID, event.eventID) && Objects.equals(eventLocation, event.eventLocation) && Objects.equals(receiptDate, event.receiptDate) && Objects.equals(m_Evaluation, event.m_Evaluation);
+    return claimValue == event.claimValue && Objects.equals(customerID, event.customerID) && Objects.equals(documents, event.documents) && Objects.equals(eventDate, event.eventDate) && Objects.equals(eventDescription, event.eventDescription) && Objects.equals(eventID, event.eventID) && Objects.equals(eventLocation, event.eventLocation) && Objects.equals(receiptDate, event.receiptDate) && Objects.equals(
+				evaluation, event.evaluation);
 	}
 
 }

--- a/src/main/EventList.java
+++ b/src/main/EventList.java
@@ -1,3 +1,4 @@
+package main;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/EventList.java
+++ b/src/main/EventList.java
@@ -1,0 +1,25 @@
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author �ڼֹ�
+ * @version 1.0
+ * @created 11-5-2025 ���� 11:25:09
+ */
+public interface EventList {
+
+
+	public boolean delete(String eventID);
+	public boolean insert(Event event);
+
+	//search
+	public ArrayList<Event> searchEvent(String key, String value);
+	public ArrayList<Evaluation> searchEvaluation(String key, String value);
+	public ArrayList<Compensation> searchCompensation(String key, String value);
+
+	//update
+	public boolean update(Event event);
+	public boolean update(Evaluation evaluation);
+	public boolean update(Compensation compensation);
+
+}

--- a/src/main/EventListImpl.java
+++ b/src/main/EventListImpl.java
@@ -1,0 +1,153 @@
+import java.util.ArrayList;
+
+public class EventListImpl implements EventList {
+
+	public ArrayList<Event> Events;
+
+	public EventListImpl(){
+		Events = new ArrayList<>();
+	}
+
+	/**
+	 * 
+	 * @param eventID
+	 */
+	public boolean delete(String eventID){
+		for (Event event : Events) {
+			if (String.valueOf(event.getEventID()).equals(eventID)) {
+				Events.remove(event);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public boolean delete(Event tragetEvent){
+		for (Event event : Events) {
+			if (event.equals(tragetEvent)) {
+				Events.remove(event);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean insert(Event event) {
+		if(event==null)return false;
+		return Events.add(event);
+	}
+
+
+//Search
+	@Override
+	public ArrayList<Event> searchEvent(String key, String value) {
+		ArrayList<Event> result = new ArrayList<>();
+		for(Event event : this.Events){
+			switch (key.toLowerCase()){
+				case "keyword":
+					if(event.toString().toLowerCase().contains(value.toLowerCase())) result.add(event);
+					break;
+				case "state":
+					if(event.getState() == ProcessState.fromString(value)) result.add(event);
+					break;
+				case "all":
+					result.add(event);
+					break;
+				default:
+					System.out.println("지원하지 않는 검색 필드입니다: " + key);
+					return result;
+			}
+		}
+		return result;
+	}
+
+	@Override
+	public ArrayList<Evaluation> searchEvaluation(String key, String value) {
+		ArrayList<Evaluation> result = new ArrayList<>();
+		for(Event event : this.Events){
+			Evaluation evaluation = event.getM_Evaluation();
+			if(evaluation==null) continue;
+			switch (key.toLowerCase()){
+				case "keyword":
+					if(evaluation.toString().toLowerCase().contains(value.toLowerCase())) result.add(evaluation);
+					break;
+				case "state":
+					if(evaluation.getState() == ProcessState.fromString(value)) result.add(evaluation);
+					break;
+				case "all":
+					result.add(evaluation);
+					break;
+				default:
+					System.out.println("지원하지 않는 검색 필드입니다: " + key);
+					return result;
+			}
+		}
+		return result;
+	}
+
+	@Override
+	public ArrayList<Compensation> searchCompensation(String key, String value) {
+		ArrayList<Compensation> result = new ArrayList<>();
+		for(Event event : this.Events){
+			Compensation compensation = event.getM_Evaluation().getM_Compensation();
+			if(compensation==null) continue;
+			switch (key.toLowerCase()){
+				case "keyword":
+					if(compensation.toString().toLowerCase().contains(value.toLowerCase())) result.add(compensation);
+					break;
+				case "state":
+					if(compensation.getState() == ProcessState.fromString(value)) result.add(compensation);
+					break;
+				case "all":
+					result.add(compensation);
+					break;
+				default:
+					System.out.println("지원하지 않는 검색 필드입니다: " + key);
+					return result;
+			}
+		}
+		return result;
+	}
+
+
+//Update
+	@Override
+	public boolean update(Event updatedEvent) {
+		for (int i = 0; i < Events.size(); i++) {
+			Event existingEvents = Events.get(i);
+			if (existingEvents.getEventID().equals(updatedEvent.getEventID())) {
+				this.Events.set(i, updatedEvent);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean update(Evaluation updatedEvaluation) {
+		// 수정된 코드
+    // 리스트에서 Event 객체를 가져옵니다.
+    for (Event eventInList : Events) {
+      Evaluation existingEvaluation = eventInList.getM_Evaluation();
+      if (existingEvaluation.getEvaluationID().equals(updatedEvaluation.getEvaluationID())) {
+        eventInList.setM_Evaluation(updatedEvaluation);
+        return true;
+      }
+    }
+		return false;
+	}
+
+	@Override
+	public boolean update(Compensation compensation) {
+    for (Event event : Events) {
+      Compensation existingCompensation = event.getM_Evaluation().getM_Compensation();
+      if (existingCompensation.getCompensationID().equals(compensation.getCompensationID())) {
+        event.getM_Evaluation().setM_Compensation(compensation);
+        return true;
+      }
+    }
+		return false;
+//update compensation
+	}
+}//end EventListImpl

--- a/src/main/EventListImpl.java
+++ b/src/main/EventListImpl.java
@@ -1,3 +1,5 @@
+
+package main;
 import java.util.ArrayList;
 
 public class EventListImpl implements EventList {
@@ -51,6 +53,9 @@ public class EventListImpl implements EventList {
 				case "state":
 					if(event.getState() == ProcessState.fromString(value)) result.add(event);
 					break;
+				case "id":
+					if(event.getEventID().equals(value)) result.add(event);
+					break;
 				case "all":
 					result.add(event);
 					break;
@@ -73,7 +78,10 @@ public class EventListImpl implements EventList {
 					if(evaluation.toString().toLowerCase().contains(value.toLowerCase())) result.add(evaluation);
 					break;
 				case "state":
-					if(evaluation.getState() == ProcessState.fromString(value)) result.add(evaluation);
+					if(evaluation.getResultOfEvaluation() == ProcessState.fromString(value)) result.add(evaluation);
+					break;
+				case "id":
+					if(evaluation.getEvaluationID().equals(value)) result.add(evaluation);
 					break;
 				case "all":
 					result.add(evaluation);
@@ -90,7 +98,7 @@ public class EventListImpl implements EventList {
 	public ArrayList<Compensation> searchCompensation(String key, String value) {
 		ArrayList<Compensation> result = new ArrayList<>();
 		for(Event event : this.Events){
-			Compensation compensation = event.getM_Evaluation().getM_Compensation();
+			Compensation compensation = event.getM_Evaluation().getCompensation();
 			if(compensation==null) continue;
 			switch (key.toLowerCase()){
 				case "keyword":
@@ -98,6 +106,9 @@ public class EventListImpl implements EventList {
 					break;
 				case "state":
 					if(compensation.getState() == ProcessState.fromString(value)) result.add(compensation);
+					break;
+				case "id":
+					if(compensation.getCompensationID().equals(value)) result.add(compensation);
 					break;
 				case "all":
 					result.add(compensation);
@@ -141,9 +152,9 @@ public class EventListImpl implements EventList {
 	@Override
 	public boolean update(Compensation compensation) {
     for (Event event : Events) {
-      Compensation existingCompensation = event.getM_Evaluation().getM_Compensation();
+      Compensation existingCompensation = event.getM_Evaluation().getCompensation();
       if (existingCompensation.getCompensationID().equals(compensation.getCompensationID())) {
-        event.getM_Evaluation().setM_Compensation(compensation);
+        event.getM_Evaluation().setCompensation(compensation);
         return true;
       }
     }

--- a/src/main/EventListImpl.java
+++ b/src/main/EventListImpl.java
@@ -51,7 +51,7 @@ public class EventListImpl implements EventList {
 					if(event.toString().toLowerCase().contains(value.toLowerCase())) result.add(event);
 					break;
 				case "state":
-					if(event.getState() == ProcessState.fromString(value)) result.add(event);
+					if(event.getEvaluation().getResultOfEvaluation() == ProcessState.fromString(value)) result.add(event);
 					break;
 				case "id":
 					if(event.getEventID().equals(value)) result.add(event);
@@ -71,7 +71,7 @@ public class EventListImpl implements EventList {
 	public ArrayList<Evaluation> searchEvaluation(String key, String value) {
 		ArrayList<Evaluation> result = new ArrayList<>();
 		for(Event event : this.Events){
-			Evaluation evaluation = event.getM_Evaluation();
+			Evaluation evaluation = event.getEvaluation();
 			if(evaluation==null) continue;
 			switch (key.toLowerCase()){
 				case "keyword":
@@ -98,7 +98,7 @@ public class EventListImpl implements EventList {
 	public ArrayList<Compensation> searchCompensation(String key, String value) {
 		ArrayList<Compensation> result = new ArrayList<>();
 		for(Event event : this.Events){
-			Compensation compensation = event.getM_Evaluation().getCompensation();
+			Compensation compensation = event.getEvaluation().getCompensation();
 			if(compensation==null) continue;
 			switch (key.toLowerCase()){
 				case "keyword":
@@ -140,9 +140,9 @@ public class EventListImpl implements EventList {
 		// 수정된 코드
     // 리스트에서 Event 객체를 가져옵니다.
     for (Event eventInList : Events) {
-      Evaluation existingEvaluation = eventInList.getM_Evaluation();
+      Evaluation existingEvaluation = eventInList.getEvaluation();
       if (existingEvaluation.getEvaluationID().equals(updatedEvaluation.getEvaluationID())) {
-        eventInList.setM_Evaluation(updatedEvaluation);
+        eventInList.setEvaluation(updatedEvaluation);
         return true;
       }
     }
@@ -152,9 +152,9 @@ public class EventListImpl implements EventList {
 	@Override
 	public boolean update(Compensation compensation) {
     for (Event event : Events) {
-      Compensation existingCompensation = event.getM_Evaluation().getCompensation();
+      Compensation existingCompensation = event.getEvaluation().getCompensation();
       if (existingCompensation.getCompensationID().equals(compensation.getCompensationID())) {
-        event.getM_Evaluation().setCompensation(compensation);
+        event.getEvaluation().setCompensation(compensation);
         return true;
       }
     }

--- a/src/main/LoadData.java
+++ b/src/main/LoadData.java
@@ -33,6 +33,12 @@ public class LoadData {
 			ProductManagement productManagement = new ProductManagement(numOfEmployees, EmployeeType.ProductManagement, customerList);
 			employeeList.insert(productManagement);
 		}
+		for (int i = 0; i < 3; i++) { // add temp three lossAdjuster
+			int numOfEmployees = employeeList.employees.size();
+			LossAdjuster lossAdjuster = new LossAdjuster(numOfEmployees, EmployeeType.LossAdjuster);
+			lossAdjuster.genrateDummy(10);
+			employeeList.insert(lossAdjuster);
+		}
 
 	}
 	public void loadInsuranceProductData() {

--- a/src/main/LossAdjuster.java
+++ b/src/main/LossAdjuster.java
@@ -22,7 +22,7 @@ package main;
 	public boolean evaluateCompensation(String eventID, boolean isReceipt){
 		Event targetEvent = this.EventList.searchEvent("id",eventID).getFirst();
 		if(targetEvent==null) return false;
-		Evaluation targetEvaluation = targetEvent.getM_Evaluation();
+		Evaluation targetEvaluation = targetEvent.getEvaluation();
 		targetEvaluation.receiptEvaluation(isReceipt);
 		EventList.update(targetEvaluation);
 		if(isReceipt) System.out.println("보상 심사가 완료되었습니다.");
@@ -40,9 +40,9 @@ package main;
 	public boolean payCompensation(String compensationID, boolean isPaid) {
 		Compensation targetCompensation = this.EventList.searchCompensation("id",compensationID).getFirst();
 		if(targetCompensation==null) return false;
-		targetCompensation.setResultOfPaid(isPaid);
+		targetCompensation.receiptCompensation(isPaid);
 		this.EventList.update(targetCompensation);
-		if(isPaid) System.out.println("보상 지급이 완료되었습니다: " + targetCompensation);
+		if(isPaid) System.out.println("보상 지급이 완료되었습니다.");
 		else System.out.println("보상 지급이 거부되었습니다.");
 		return EventList.update(targetCompensation);
 	}
@@ -61,9 +61,13 @@ package main;
 					.build();
 
 			ev.setCompensation(c);
-			e.setM_Evaluation(ev);
+			e.setEvaluation(ev);
 			EventList.insert(e);
 		}
+	}
+
+	public EventList getEventList(){
+		return this.EventList;
 	}
 
 	public static void main(String[] args) {

--- a/src/main/LossAdjuster.java
+++ b/src/main/LossAdjuster.java
@@ -1,70 +1,53 @@
-
-import java.util.List;
-import java.util.Random;
-import java.util.Scanner;
-import java.util.random.RandomGenerator;
+package main;
 
 /**
  * @author �ڼֹ�
  * @version 1.0
  * @created 11-5-2025 ���� 11:25:09
  */
-// public class LossAdjuster extends Employee {
-	public class LossAdjuster{
-		private EventList EventList;
-	public LossAdjuster(){
-		this.EventList = new EventListImpl();
-	}
-//	public void finalize() throws Throwable {
-//		super.finalize();
-//	}
+ public class LossAdjuster extends Employee {
+	 private final EventList EventList;
+	 public LossAdjuster(int numOfEmployees, EmployeeType employeeType) {
+			 super(numOfEmployees,employeeType);
+		 this.EventList = new EventListImpl();
+		 }
 
-	public boolean evaluateCompensation(String eventID){
-		// Need to look up customer information, class diagram needs to be modified, can't be implemented in current state
-		return false;
-	}
-
-
-	public void payCompensation() {
-		List<Compensation> compensations = EventList.searchCompensation("all", "");
-		if (compensations.isEmpty()) {
-			System.out.println("지급할 보상금이 없습니다.");
-			return;
-		}
-		System.out.println("지급할 보상금을 선택하세요:");
-		for (int i = 0; i < compensations.size(); i++) {
-			System.out.println((i + 1) + "|| " + compensations.get(i).getCompensationID()+", paidState: "+compensations.get(i).getState()+", claimsPaid: "+compensations.get(i).getClaimsPaid());
-		}
-		Scanner scanner = new Scanner(System.in);
-		int choice = scanner.nextInt();
-		scanner.nextLine(); // Consume newline
-
-		if (choice > 0 && choice <= compensations.size()) {
-			Compensation selectedCompensation = compensations.get(choice - 1);
-			System.out.println("선택한 보상 정보:");
-			System.out.println(selectedCompensation);
-			System.out.println("보상을 지급하시겠습니까? (y/n) 취소하려면 c를 입력해주세요.");
-			String confirm = scanner.nextLine();
-			if (confirm.equalsIgnoreCase("n")) {
-				System.out.println("보상 지급이 거부되었습니다.");
-				selectedCompensation.receiptCompensation(false);
-				EventList.update(selectedCompensation);
-				return;
-			} else if (confirm.equalsIgnoreCase("y")) {
-				System.out.println("보상 지급이 완료되었습니다: " + selectedCompensation.getCompensationID());
-				selectedCompensation.receiptCompensation(true);
-				EventList.update(selectedCompensation);
-			}	else if(confirm.equalsIgnoreCase("c")) {
-				System.out.println("보상 지급이 취소되었습니다.");
-			}
-			else {
-				System.out.println("잘못된 선택입니다.");
-			}
-		}
+	/**
+	 * 이벤트ID받고, 심사의 상태를 변경한다.
+	 *
+	 * @param eventID 심사할 사건의 ID
+	 * @param isReceipt 심사 결과 (true: 승인, false: 거절)
+	 * @return 심사 성공 여부 (true: 성공, false: 실패 - 해당 사건 ID가 없는 경우)
+	 */
+	public boolean evaluateCompensation(String eventID, boolean isReceipt){
+		Event targetEvent = this.EventList.searchEvent("id",eventID).getFirst();
+		if(targetEvent==null) return false;
+		Evaluation targetEvaluation = targetEvent.getM_Evaluation();
+		targetEvaluation.receiptEvaluation(isReceipt);
+		EventList.update(targetEvaluation);
+		if(isReceipt) System.out.println("보상 심사가 완료되었습니다.");
+		else System.out.println("보상 심사가 거절되었습니다.");
+		return true;
 	}
 
+	/**
+	 * 심사가 완료된 사고들의 보상금을 지급하거나 거부합니다.
+	 *
+	 * @param compensationID 지급 또는 거부할 보상금의 ID
+	 * @param isPaid         true면지급, false면 거부
+	 * @return 보상금 지급 성공시 true를, 보상금 ID가 유효하지 않거나 업데이트에 실패한 경우 false
+	 */
+	public boolean payCompensation(String compensationID, boolean isPaid) {
+		Compensation targetCompensation = this.EventList.searchCompensation("id",compensationID).getFirst();
+		if(targetCompensation==null) return false;
+		targetCompensation.setResultOfPaid(isPaid);
+		this.EventList.update(targetCompensation);
+		if(isPaid) System.out.println("보상 지급이 완료되었습니다: " + targetCompensation);
+		else System.out.println("보상 지급이 거부되었습니다.");
+		return EventList.update(targetCompensation);
+	}
 
-	//임시, 더미데이터
+	//임시, 더미데이터생성기
 	public void genrateDummy(int count){
 
 		for(int i=0;i<count;i++) {
@@ -77,15 +60,15 @@ import java.util.random.RandomGenerator;
 			Compensation c = new Compensation.Builder(CompensationID,ev.getEvaluationID(), customerID).claimsPaid((int)(Math.random()*1000000+10))
 					.build();
 
-			ev.setM_Compensation(c);
+			ev.setCompensation(c);
 			e.setM_Evaluation(ev);
 			EventList.insert(e);
 		}
 	}
 
 	public static void main(String[] args) {
-		LossAdjuster la = new LossAdjuster();
+		LossAdjuster la = new LossAdjuster(1, EmployeeType.LossAdjuster);
 		la.genrateDummy(10);
-		la.payCompensation();
+//		la.payCompensation();
 	}
 }//end LossAdjuster

--- a/src/main/LossAdjuster.java
+++ b/src/main/LossAdjuster.java
@@ -1,0 +1,91 @@
+
+import java.util.List;
+import java.util.Random;
+import java.util.Scanner;
+import java.util.random.RandomGenerator;
+
+/**
+ * @author �ڼֹ�
+ * @version 1.0
+ * @created 11-5-2025 ���� 11:25:09
+ */
+// public class LossAdjuster extends Employee {
+	public class LossAdjuster{
+		private EventList EventList;
+	public LossAdjuster(){
+		this.EventList = new EventListImpl();
+	}
+//	public void finalize() throws Throwable {
+//		super.finalize();
+//	}
+
+	public boolean evaluateCompensation(String eventID){
+		// Need to look up customer information, class diagram needs to be modified, can't be implemented in current state
+		return false;
+	}
+
+
+	public void payCompensation() {
+		List<Compensation> compensations = EventList.searchCompensation("all", "");
+		if (compensations.isEmpty()) {
+			System.out.println("지급할 보상금이 없습니다.");
+			return;
+		}
+		System.out.println("지급할 보상금을 선택하세요:");
+		for (int i = 0; i < compensations.size(); i++) {
+			System.out.println((i + 1) + "|| " + compensations.get(i).getCompensationID()+", paidState: "+compensations.get(i).getState()+", claimsPaid: "+compensations.get(i).getClaimsPaid());
+		}
+		Scanner scanner = new Scanner(System.in);
+		int choice = scanner.nextInt();
+		scanner.nextLine(); // Consume newline
+
+		if (choice > 0 && choice <= compensations.size()) {
+			Compensation selectedCompensation = compensations.get(choice - 1);
+			System.out.println("선택한 보상 정보:");
+			System.out.println(selectedCompensation);
+			System.out.println("보상을 지급하시겠습니까? (y/n) 취소하려면 c를 입력해주세요.");
+			String confirm = scanner.nextLine();
+			if (confirm.equalsIgnoreCase("n")) {
+				System.out.println("보상 지급이 거부되었습니다.");
+				selectedCompensation.receiptCompensation(false);
+				EventList.update(selectedCompensation);
+				return;
+			} else if (confirm.equalsIgnoreCase("y")) {
+				System.out.println("보상 지급이 완료되었습니다: " + selectedCompensation.getCompensationID());
+				selectedCompensation.receiptCompensation(true);
+				EventList.update(selectedCompensation);
+			}	else if(confirm.equalsIgnoreCase("c")) {
+				System.out.println("보상 지급이 취소되었습니다.");
+			}
+			else {
+				System.out.println("잘못된 선택입니다.");
+			}
+		}
+	}
+
+
+	//임시, 더미데이터
+	public void genrateDummy(int count){
+
+		for(int i=0;i<count;i++) {
+			String customerID = "CustomerN"+i;
+			String EventID = "EventN"+i;
+			String EvaluationID = "EvaluationN"+i;
+			String CompensationID = "CompensationN"+i;
+			Event e = new Event.Builder(EventID,customerID).build();
+			Evaluation ev = new Evaluation.Builder(EvaluationID,e.getEventID(), customerID).build();
+			Compensation c = new Compensation.Builder(CompensationID,ev.getEvaluationID(), customerID).claimsPaid((int)(Math.random()*1000000+10))
+					.build();
+
+			ev.setM_Compensation(c);
+			e.setM_Evaluation(ev);
+			EventList.insert(e);
+		}
+	}
+
+	public static void main(String[] args) {
+		LossAdjuster la = new LossAdjuster();
+		la.genrateDummy(10);
+		la.payCompensation();
+	}
+}//end LossAdjuster

--- a/src/main/Main.java
+++ b/src/main/Main.java
@@ -23,7 +23,7 @@ public class Main {
 		loadData.loadEmployeeData();
 		loadData.loadInsuranceProductData();
 		
-		loginedEmployee = login("6");
+		loginedEmployee = login("7");
 
 		Menu menu = new Menu(customerList, employeeList,insuranceProductList, loginedEmployee);
 		while (true) {

--- a/src/main/Menu.java
+++ b/src/main/Menu.java
@@ -435,11 +435,17 @@ public class Menu {
 
 	//----------------LossAdjuster--------------------------------------
 
+	/**
+	 * search관련 메소드 분리되지 않음
+	 */
 	private void payCompensation(){
-		LossAdjuster lossAdjuster = (LossAdjuster) loginedEmployee;
-		EventList eventList = lossAdjuster.getEventList();
+		LossAdjuster lossAdjuster = (LossAdjuster) loginedEmployee; //관리자 로딩
+
+		EventList eventList = lossAdjuster.getEventList(); //컴포지션... 관리자가 리스트를 들고 있음, 가져와야함
+
+		//보상 지급 대기중인 보상 조회 로직, 라인넘버 통해서 선택함,
 		System.out.println("===CompensationList===");
-		ArrayList<Compensation> compensations = eventList.searchCompensation("state","Awaiting");
+		ArrayList<Compensation> compensations = eventList.searchCompensation("state","Awaiting"); // 일반 보상 지급이 아직 되지 않은 경우만 골라오긴 하는데, 보상 지급 결정이 내려졌는지가 반영이 되야할것같음.. DB 마렵네
 		for(int i = 0; i<compensations.size(); i++){
 			Compensation targetCompensation = compensations.get(i);
 			System.out.println((i+1)+": Customer:"+targetCompensation.getCustomerID()+", Amount charged: "+targetCompensation.getAmountOfPaid());
@@ -448,6 +454,8 @@ public class Menu {
 		Compensation selectedCompensation = compensations.get(getUserSelectInt());
 		Evaluation selectedEvaluation = eventList.searchEvaluation("id",selectedCompensation.getEvaluationID()).getFirst();
 		Event selectedEvent = eventList.searchEvent("id",selectedEvaluation.getEventID()).getFirst();
+
+		//상세정보 표시 및 보상 지급 선택
 		System.out.println("==상세정보==\n"+selectedEvent+", Amount charged: "+selectedEvaluation.getCompensation().getAmountOfPaid());
 		System.out.println("보상을 지급하시겠습니까?");
 		switch (getUserSelectYorN()){
@@ -462,7 +470,6 @@ public class Menu {
 				break;
 		}
 	}
-
 	private void evaluateCompensation(){
 
 	}

--- a/src/main/ProcessState.java
+++ b/src/main/ProcessState.java
@@ -1,3 +1,4 @@
+package main;
 public enum ProcessState {
     Awaiting, Completed, Rejected
     ;

--- a/src/main/ProcessState.java
+++ b/src/main/ProcessState.java
@@ -1,0 +1,17 @@
+public enum ProcessState {
+    Awaiting, Completed, Rejected
+    ;
+
+    public static ProcessState fromString(String state) {
+        switch (state.toLowerCase()) {
+            case "awaiting":
+                return Awaiting;
+            case "completed":
+                return Completed;
+            case "rejected":
+                return Rejected;
+            default:
+                throw new IllegalArgumentException("Invalid ReceiptState: " + state);
+        }
+    }
+}

--- a/src/main/UserSelection.java
+++ b/src/main/UserSelection.java
@@ -1,0 +1,5 @@
+package main;
+
+public enum UserSelection {
+  Yes,No,Cancel
+}


### PR DESCRIPTION
payCompensation메소드는 아직 하자가 있음,
아직 지급하지 않은 보상을 검색해서 가져오지만, 보상이 승인이 났는지 나지 않았는지를 체크하지 못함-> EventLIst에서 Compensation및 Evaluation Search 메소드의 return값을 Event리스트로 바꾸면 해결 가능할듯 하다.

보상을 심사하다 시나리오는 시나리오의 수정이 필요해 보인다.
<img width="572" alt="스크린샷 2025-05-14 오후 4 37 55" src="https://github.com/user-attachments/assets/1495d1fe-c828-4815-9dab-c154b567c5e4" />

1. 손해사정사는 "보상심사" 메뉴를 누른다
2. 시스템은 "보상심사"창을 띄운다
3. 사고를 조회하다: 손해사정사는 심사 대기중인 사고의 세부 정보를 확인한다
4. 고객 정보를 조회하다: 고객의 세부 정보를 확인한다.
5. 계약을 조회하다: 고객의 계약들을 조회한다(여기서 어떤 계약을 통해 보상을 지급할것이며, 보상에 대한 정보가 자동으로 계산되어야 한다)
6. 손해사정사는 "보상지급"버튼 을 누른다.
7. 시스템은 "보상 심사 완료되었습니다" 문구 출력